### PR TITLE
Lifetime and duration in seconds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ pkg
 .idea
 
 ## PROJECT::SPECIFIC
+.ruby-version
+.ruby-gemset

--- a/lib/models/turkee_task.rb
+++ b/lib/models/turkee_task.rb
@@ -76,7 +76,7 @@ module Turkee
 
         hit.description = hit_description
         hit.reward = reward
-        hit.lifetime = lifetime.to_i.days.seconds.to_i
+        hit.lifetime = lifetime.to_i  # duration in seconds
         hit.duration = duration.to_i if duration  # duration in seconds
         hit.question(f_url, :frame_height => HIT_FRAMEHEIGHT)
         unless qualifications.empty?


### PR DESCRIPTION
- Ignore rvm settings
- Convert lifetime to seconds
